### PR TITLE
Fixed platform selection in loadTsConfig.ts

### DIFF
--- a/src/loadTsConfig.ts
+++ b/src/loadTsConfig.ts
@@ -36,7 +36,7 @@ export function defaultOutDir(
     .split(path.sep)
     .join("-")
     .slice(1);
-  if (platform.name === "win32") {
+  if (platform() === "win32") {
     smushedPath = smushedPath.replace(/^:/, "");
   }
   return path.join(os.homedir(), ".cache", programName, smushedPath);


### PR DESCRIPTION
`os.platform` is a function (https://nodejs.org/api/os.html#osplatform), returning a string.

Fixes #20