### PR TITLE
Add paragraph about caveat in path construction not working as expected due to caching in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ TypeScript **types** provide free error checking, and free IDE support for getti
 ### Fast
 Parsing TypeScript config files is plenty quick. config-file-ts caches the TypeScript output. 
 
+> [!WARNING]
+> Because the output is cached at a different location, constructing paths from the file using `__dirname` or `import.meta.dirname` will not work as expected.
+
 Assuming TypeScript is in your environment, config-file-ts adds about 5kb to your program, or 1.5kb minified.
 ### How to use
 ```bash


### PR DESCRIPTION
I'm using `electron-builder` which uses `read-config-file` which uses `config-file-ts`. In my application I tried to construct paths using `import.meta.dirname`/`__dirname`, which doesn't work as expected since these output the location of the cached file in the user folder.

This PR adds a warning message to the README so people are aware of this caveat.